### PR TITLE
PRD-5263 - Readied library for inclusion in main build

### DIFF
--- a/cgg-reporting/.gitignore
+++ b/cgg-reporting/.gitignore
@@ -1,0 +1,1 @@
+test-lib

--- a/cgg-reporting/build.properties
+++ b/cgg-reporting/build.properties
@@ -17,9 +17,9 @@
 
 project.revision=TRUNK-SNAPSHOT
 ivy.artifact.group=pentaho
-ivy.artifact.id=libcgg
-impl.title=CGG Lib
-impl.productID=lib-cgg
+ivy.artifact.id=cgg-reporting
+impl.title=CGG to Pentaho Reporting Bridge
+impl.productID=cgg-reporting
 src.dir=${basedir}/src
 testsrc.dir=${basedir}/test-src
 

--- a/cgg-reporting/build.xml
+++ b/cgg-reporting/build.xml
@@ -7,7 +7,7 @@
   
   See build-res/subfloor.xml for more details
 ============================================================================-->
-<project name="libcgg" basedir="." default="default">
+<project name="cgg-reporting" basedir="." default="default">
 	
 	<description>
 	  This build file is used to create the API project

--- a/cgg-reporting/ivy.xml
+++ b/cgg-reporting/ivy.xml
@@ -17,6 +17,7 @@
 
 	<dependencies defaultconf="default_internal->default">
     <!-- internal dependencies -->
+		<dependency org="pentaho" name="cgg-core" rev="TRUNK-SNAPSHOT"/>
 
 		<!--  external dependencies -->
 


### PR DESCRIPTION
This updates the ivy-file to pull in CGG-core, and renames the project to "cgg-reporting" to be in sync with the other cgg-modules.
