### PR TITLE
[CDF-414] - CCC - spinoff code of the "pvc.data" namespace into a new namespace: CDO

### DIFF
--- a/cgg-core/build.xml
+++ b/cgg-core/build.xml
@@ -52,6 +52,7 @@
       <fileset dir="${js.expanded.lib.dir}/ccc/amd">
         <include name="def.js" />
         <include name="pvc.js" />
+        <include name="cdo.js" />
         <include name="protovis.js" />
       </fileset>
 


### PR DESCRIPTION
- Missing copy-of cdo.js file in build.xml.

@pamval please review.
