### PR TITLE
[BACKLOG-2540] - AMD Conversion - Adding a simulated setTimeout to support use of Promises

### DIFF
--- a/cgg-core/src/pt/webdetails/cgg/resources/cgg/dom.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cgg/dom.js
@@ -65,6 +65,12 @@ define([
         function syncGlobal() {
             if(cgg.useGlobal) {
                 var global = util.global;
+                
+                // Rhino binds "global" to some apparently unnecessary native function.
+                // This messes up scripts that expect the global "global" property to
+                // be, actually, the JS global object.
+                global.global    = global;
+                
                 global.window    = global;
                 global.document  = doc;
                 global._document = doc._node;


### PR DESCRIPTION
* Also need this because an existing "property" "global" that points to something other than the global object
  is tricking the shim and not installing `Promise` in the real global object, as it should...
* Changed the value of that global "property" to point to the global object, and, apparently, CGG keeps printing, happily.
  Could not find documentation for the global "global" property, for Rhino...

@pamval please review.