### PR TITLE
[BACKLOG-2548] - Some cleanup.

### DIFF
--- a/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/BaseCccComponent.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/BaseCccComponent.js
@@ -29,6 +29,13 @@ define([
             var pvc = ccc.pvc;
             var def = ccc.def;
 
+            // Not all versions of CCC have def.describe/pvc.stringify.
+            var describe = def.describe || pvc.describe;
+            if(def.describe)
+                cgg.win.console.stringify = function(s) {
+                    return describe(s, {ownOnly: false});
+                };
+
             if(cgg.useGlobal) {
                 var global = util.global;
                 global.pv  = ccc.pv;
@@ -144,12 +151,6 @@ define([
     dash.registerControlClassHandler(function(typeName) {
         if((/^ccc/i).test(typeName)) return BaseCccComponent;
     });
-
-    // Not all versions of CCC have def.describe/pvc.stringify.
-    // if(def.describe)
-    //     cgg.win.console.stringify = function(s) {
-    //         return def.describe(s, {ownOnly: false});
-    //     };
 
     return BaseCccComponent;
 });

--- a/cgg-core/src/pt/webdetails/cgg/resources/cgg/dom.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cgg/dom.js
@@ -65,12 +65,12 @@ define([
         function syncGlobal() {
             if(cgg.useGlobal) {
                 var global = util.global;
-                
+
                 // Rhino binds "global" to some apparently unnecessary native function.
                 // This messes up scripts that expect the global "global" property to
                 // be, actually, the JS global object.
                 global.global    = global;
-                
+
                 global.window    = global;
                 global.document  = doc;
                 global._document = doc._node;
@@ -201,8 +201,9 @@ define([
             return createStyle(this._el.getStyle());
         },
 
+        // NOTE: This doesn't really return computed values...
         get computedStyle() {
-            return createStyle(this._el.getComputedStyle());
+            return createStyle(this._el.getComputedStyle(this._el, null));
         },
 
         get parentNode() {
@@ -220,6 +221,11 @@ define([
 
         get namespaceURI() {
             return this._el.getNamespaceURI();
+        },
+
+        // def.describe uses this method to detect a DOM node...
+        cloneNode: function() {
+            throw new Error("Not supported");
         },
 
         addEventListener: function() {},

--- a/cgg-core/src/pt/webdetails/cgg/resources/cgg/parameters.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cgg/parameters.js
@@ -118,7 +118,6 @@ define([
                     params.put(name, v);
                 }
 
-                // TODO: could apply JSON.stringify here...
                 out && out.push(
                     "  " + name + " = " +
                     cgg.win.console.stringify(v) +

--- a/cgg-core/src/pt/webdetails/cgg/resources/define.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/define.js
@@ -554,7 +554,7 @@
     Module.prototype.require = function() {
         DEBUG && print("BEG require on '" + this.id + "'");
         try {
-            var depId, depIds, fun;
+            var depId, depIds, callback, errback;
 
             var i = -1;
             var args = arguments;
@@ -562,14 +562,17 @@
             while(++i < L) {
                 var a = args[i];
                 switch(typeof a) {
-                    case 'function': fun   = a; break;
+                    case 'function':
+                        // Guard against errback.
+                        if(!callback) callback = a;
+                        break;
                     case 'string':   depId = a; break;
                     case 'object':   if(a instanceof Array) depIds = a; break;
                 }
             }
 
-            if(fun) {
-                this.apply(depIds, fun);
+            if(callback) {
+                this.apply(depIds, callback);
             } else {
                 // Synchronous only syntax
                 if(depId ) return this.requireOne(depId);


### PR DESCRIPTION
* New Synchronous Module Definition version
* Add Element#cloneNode method so that def.describe doesn't crash trying to describe a DOM Element (it detects DOM elements by the existence of that method).

@pamval please review.