### PR TITLE
Remove dist->publish and additional publish build target dependencies

### DIFF
--- a/cgg-core/build.xml
+++ b/cgg-core/build.xml
@@ -40,7 +40,6 @@
 	<!-- Override default dist target to do a dist-full instead -->
 	<target name="dist" depends="resolve, copy-ccc-dependencies, dist-full"/>
 
-    <target name="publish" depends="dist, dist-source, cobertura, publish-nojar">
     </target>
 
 

--- a/cgg-core/build.xml
+++ b/cgg-core/build.xml
@@ -40,8 +40,6 @@
 	<!-- Override default dist target to do a dist-full instead -->
 	<target name="dist" depends="resolve, copy-ccc-dependencies, dist-full"/>
 
-    </target>
-
 
   <target name="copy-ccc-dependencies" depends="subfloor-js.resolve-js">
      <!-- copy ccc build -->


### PR DESCRIPTION
Can we take the override of subfloor publish target out of the build.xml here?

This causes two issues on the nightly builds:
Double call of the build targets because we do split out the build targets from the publish target on release.
Can’t publish jacoco->sonar test results because calling ‘publish’ depends on the depreciated ‘cobertura’ target that should not be used anymore.
