### PR TITLE
[CDF-647]

### DIFF
--- a/cgg-core/build.xml
+++ b/cgg-core/build.xml
@@ -40,6 +40,7 @@
 	<!-- Override default dist target to do a dist-full instead -->
 	<target name="dist" depends="resolve, copy-ccc-dependencies, dist-full"/>
 
+  <target name="clean-all" depends="subfloor.clean-all, subfloor-js.clean-js"/>
 
   <target name="copy-ccc-dependencies" depends="subfloor-js.resolve-js">
      <!-- copy ccc build -->

--- a/cgg-core/ivy.xml
+++ b/cgg-core/ivy.xml
@@ -55,7 +55,7 @@
         <!-- Not using batik-js, as this is a patched rhino-1.6R5. the patch concerns swing-filechoosers
              (see https://bugzilla.mozilla.org/show_bug.cgi?id=367627 ) and therefore is of no concern
             to us. So we can use the off-the-shelf batik 1.7 instead. -->
-        <dependency org="rhino"                  name="js"               rev="1.7R1"        conf="default_external->default"/>
+        <dependency org="rhino"                  name="js"               rev="1.7R3"        conf="default_external->default"/>
         <dependency org="com.google.code.gson"   name="gson"             rev="2.2.2"        conf='default_external->default' />
 
 
@@ -72,7 +72,7 @@
         <dependency org="commons-io" name="commons-io" rev="2.4"  conf="test->default"/>
 
         <!-- other plugin dependencies -->
-        <dependency org="pentaho"    name="cpf-core"   rev="${dependency.pentaho-cpf-plugin.revision}" conf="default_internal->default" transitive="false" changing="true" /> 
+        <dependency org="pentaho"    name="cpf-core"   rev="${dependency.pentaho-cpf-plugin.revision}" conf="default_internal->default" transitive="false" changing="true" />
 
 	</dependencies>
 </ivy-module>

--- a/cgg-core/test-gold/gold/sample1/cccRaw-svg-test.svg
+++ b/cgg-core/test-gold/gold/sample1/cccRaw-svg-test.svg
@@ -132,34 +132,34 @@ font-size: 14px;
                     </g>
                     <g transform="translate(0,4.7999)">
                         <line x1="30" x2="30" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="100.4" x2="100.4" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="170.8" x2="170.8" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="241.20000000000002" x2="241.20000000000002"
                               y1="0" y2="94.2001" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                     </g>
                     <g transform="translate(0,4.7999)">
                         <line x1="30" x2="294" y1="94.20009999999999"
                               y2="94.20009999999999" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="70.650075" y2="70.650075"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="30" x2="294" y1="47.100049999999996"
                               y2="47.100049999999996" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="23.55002499999999"
                               y2="23.55002499999999" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="-1.4210854715202004e-14"
                               y2="-1.4210854715202004e-14"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                     </g>
                     <g transform="translate(0,4.7999)">
@@ -167,14 +167,14 @@ font-size: 14px;
                             <g>
                                 <line x1="24" x2="30" y1="94.2001" y2="94.2001"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="82.4250875"
                                       y2="82.4250875"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -193,14 +193,14 @@ font-size: 9px;
                                 <line x1="24" x2="30" y1="70.650075"
                                       y2="70.650075"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="58.8750625"
                                       y2="58.8750625"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -218,14 +218,14 @@ font-size: 9px;
                             <g>
                                 <line x1="24" x2="30" y1="47.10005"
                                       y2="47.10005" shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="35.3250375"
                                       y2="35.3250375"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -244,14 +244,14 @@ font-size: 9px;
                                 <line x1="24" x2="30" y1="23.550025000000005"
                                       y2="23.550025000000005"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="11.775012500000004"
                                       y2="11.775012500000004"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -270,7 +270,7 @@ font-size: 9px;
                             <g>
                                 <line x1="24" x2="30" y1="0" y2="0"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g/>
@@ -290,7 +290,7 @@ font-size: 9px;
                         <g transform="translate(0,-7.105427357601002e-15)">
                             <line stroke-linecap="square" x1="30" x2="30" y1="0"
                                   y2="94.2001" shape-rendering="crispEdges"
-                                  stroke="rgb(102,102,102)" stroke-width="0"
+                                  stroke="rgb(102,102,102)" stroke-width="1"
                                   pointer-events="none"/>
                         </g>
                     </g>
@@ -301,13 +301,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g>
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g>
                                     <text y="3" transform="translate(0,6)"
@@ -326,13 +326,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(70.4,0)">
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(70.4,0)">
                                     <text y="3" transform="translate(0,6)"
@@ -351,13 +351,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(140.8,0)">
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(140.8,0)">
                                     <text y="3" transform="translate(0,6)"
@@ -376,7 +376,7 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(211.20000000000002,0)"/>
                                 <g transform="translate(211.20000000000002,0)">
@@ -396,7 +396,7 @@ font-size: 9px;
                             <g>
                                 <line stroke-linecap="square" x1="0" x2="264"
                                       y1="0" y2="0" shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                         </g>

--- a/cgg-core/test-gold/gold/sample1/cccStub-svg-test.svg
+++ b/cgg-core/test-gold/gold/sample1/cccStub-svg-test.svg
@@ -132,34 +132,34 @@ font-size: 14px;
                     </g>
                     <g transform="translate(0,4.7999)">
                         <line x1="30" x2="30" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="100.4" x2="100.4" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="170.8" x2="170.8" y1="0" y2="94.2001"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="241.20000000000002" x2="241.20000000000002"
                               y1="0" y2="94.2001" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                     </g>
                     <g transform="translate(0,4.7999)">
                         <line x1="30" x2="294" y1="94.20009999999999"
                               y2="94.20009999999999" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="70.650075" y2="70.650075"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                         <line x1="30" x2="294" y1="47.100049999999996"
                               y2="47.100049999999996" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="23.55002499999999"
                               y2="23.55002499999999" stroke="rgb(240,240,240)"
-                              stroke-width="0" pointer-events="none"/>
+                              stroke-width="1" pointer-events="none"/>
                         <line x1="30" x2="294" y1="-1.4210854715202004e-14"
                               y2="-1.4210854715202004e-14"
-                              stroke="rgb(240,240,240)" stroke-width="0"
+                              stroke="rgb(240,240,240)" stroke-width="1"
                               pointer-events="none"/>
                     </g>
                     <g transform="translate(0,4.7999)">
@@ -167,14 +167,14 @@ font-size: 14px;
                             <g>
                                 <line x1="24" x2="30" y1="94.2001" y2="94.2001"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="82.4250875"
                                       y2="82.4250875"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -193,14 +193,14 @@ font-size: 9px;
                                 <line x1="24" x2="30" y1="70.650075"
                                       y2="70.650075"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="58.8750625"
                                       y2="58.8750625"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -218,14 +218,14 @@ font-size: 9px;
                             <g>
                                 <line x1="24" x2="30" y1="47.10005"
                                       y2="47.10005" shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="35.3250375"
                                       y2="35.3250375"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -244,14 +244,14 @@ font-size: 9px;
                                 <line x1="24" x2="30" y1="23.550025000000005"
                                       y2="23.550025000000005"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
                                 <line x1="27" x2="30" y1="11.775012500000004"
                                       y2="11.775012500000004"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g>
@@ -270,7 +270,7 @@ font-size: 9px;
                             <g>
                                 <line x1="24" x2="30" y1="0" y2="0"
                                       shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                             <g/>
@@ -290,7 +290,7 @@ font-size: 9px;
                         <g transform="translate(0,-7.105427357601002e-15)">
                             <line stroke-linecap="square" x1="30" x2="30" y1="0"
                                   y2="94.2001" shape-rendering="crispEdges"
-                                  stroke="rgb(102,102,102)" stroke-width="0"
+                                  stroke="rgb(102,102,102)" stroke-width="1"
                                   pointer-events="none"/>
                         </g>
                     </g>
@@ -301,13 +301,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g>
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g>
                                     <text y="3" transform="translate(0,6)"
@@ -326,13 +326,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(70.4,0)">
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(70.4,0)">
                                     <text y="3" transform="translate(0,6)"
@@ -351,13 +351,13 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(140.8,0)">
                                     <line x1="35.2" x2="35.2" y1="0" y2="3"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(140.8,0)">
                                     <text y="3" transform="translate(0,6)"
@@ -376,7 +376,7 @@ font-size: 9px;
                                     <line x1="0" x2="0" y1="0" y2="6"
                                           shape-rendering="crispEdges"
                                           stroke="rgb(102,102,102)"
-                                          stroke-width="0" pointer-events="none"/>
+                                          stroke-width="1" pointer-events="none"/>
                                 </g>
                                 <g transform="translate(211.20000000000002,0)"/>
                                 <g transform="translate(211.20000000000002,0)">
@@ -396,7 +396,7 @@ font-size: 9px;
                             <g>
                                 <line stroke-linecap="square" x1="0" x2="264"
                                       y1="0" y2="0" shape-rendering="crispEdges"
-                                      stroke="rgb(102,102,102)" stroke-width="0"
+                                      stroke="rgb(102,102,102)" stroke-width="1"
                                       pointer-events="none"/>
                             </g>
                         </g>

--- a/cgg-core/test-src/pt/webdetails/cgg/CggGoldSampleTest.java
+++ b/cgg-core/test-src/pt/webdetails/cgg/CggGoldSampleTest.java
@@ -14,18 +14,13 @@
 package pt.webdetails.cgg;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
-public class CggGoldSampleTest extends CggGoldTestBase
-{
-  public CggGoldSampleTest()
-  {
+public class CggGoldSampleTest extends CggGoldTestBase {
+  public CggGoldSampleTest() {
   }
 
   @Test
-  @Ignore
-  public void testExecuteReports() throws Exception
-  {
+  public void testExecuteReports() throws Exception {
     runAllGoldCharts();
   }
 }

--- a/cgg-core/test-src/pt/webdetails/cgg/CggGoldTestBase.java
+++ b/cgg-core/test-src/pt/webdetails/cgg/CggGoldTestBase.java
@@ -21,290 +21,344 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import junit.framework.AssertionFailedError;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.Difference;
+import org.custommonkey.xmlunit.DifferenceConstants;
+import org.custommonkey.xmlunit.DifferenceListener;
+import org.custommonkey.xmlunit.NodeDetail;
 import org.custommonkey.xmlunit.XMLAssert;
-import org.junit.Assert;
 import org.junit.Before;
+import org.w3c.dom.Node;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
 
-public class CggGoldTestBase
-{
-  private static File checkMarkerExists(final String filename)
-  {
-    final File file = new File(filename);
-    if (file.canRead())
-    {
+public class CggGoldTestBase {
+  private static final double MIN_PIXEL_DIFFERENCE = 2;
+  private static final double VALUE_MIN = 0.01;
+  private static final String TRANSLATE_REGEX = "translate\\((.*)\\)";
+  private static final String TRANSFORM_ATTRIBUTE = "transform";
+  private static final String PATH_REGEX = "[a-zA-Z|,]";
+
+  private static File checkMarkerExists( final String filename ) {
+    final File file = new File( filename );
+    if ( file.canRead() ) {
       return file;
     }
     return null;
   }
 
   @Before
-  public void setUp() throws Exception
-  {
+  public void setUp() throws Exception {
     CggBoot.init();
   }
 
-  protected void run(final File file, final File gold)
-      throws Exception
-  {
-    final String fileNameWithoutExtension = file.getName().substring(0, file.getName().length() - 3);
+  protected void run( final File file, final File gold )
+    throws Exception {
+    final String fileNameWithoutExtension = file.getName().substring( 0, file.getName().length() - 3 );
 
     final String scriptType;
     final String outputType;
     final String fileName = file.getName();
-    if (fileName.endsWith("-svg-test.js"))
-    {
+    if ( fileName.endsWith( "-svg-test.js" ) ) {
       scriptType = "SVG";
       outputType = "svg";
-    }
-    else if (fileName.endsWith("-j2d-test.js"))
-    {
+    } else if ( fileName.endsWith( "-j2d-test.js" ) ) {
       scriptType = "J2D";
       outputType = "png";
-    }
-    else
-    {
-      throw new IllegalArgumentException(fileName);
+    } else {
+      throw new IllegalArgumentException( fileName );
     }
 
-    handleContent(executeCgg(file, scriptType, outputType),
-        new File(gold, fileNameWithoutExtension + "." + outputType), outputType);
+    handleContent( executeCgg( file, scriptType, outputType ),
+        new File( gold, fileNameWithoutExtension + "." + outputType ), outputType );
   }
 
-  private byte[] executeCgg(final File file, final String scriptType, final String outputType)
-      throws IOException, ScriptCreationException, ScriptExecuteException
-  {
-    final Map<String, Object> parameter = loadParameter(file);
+  private byte[] executeCgg( final File file, final String scriptType, final String outputType )
+    throws IOException, ScriptCreationException, ScriptExecuteException {
+    final Map<String, Object> parameter = loadParameter( file );
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     final URL scriptContext = file.getParentFile().toURI().toURL();
-    final DefaultCgg cgg = new DefaultCgg(out, scriptContext);
-    cgg.draw(file.getName(), scriptType, outputType, 800, 600, parameter);
+    final DefaultCgg cgg = new DefaultCgg( out, scriptContext );
+    cgg.draw( file.getName(), scriptType, outputType, 800, 600, parameter );
     return out.toByteArray();
   }
 
-  protected Map<String, Object> loadParameter(final File file) throws IOException
-  {
-    final String properties = file.getAbsolutePath().substring(0, file.getAbsolutePath().length() - 3) + ".properties";
+  protected Map<String, Object> loadParameter( final File file ) throws IOException {
+    final String properties =
+        file.getAbsolutePath().substring( 0, file.getAbsolutePath().length() - 3 ) + ".properties";
     final Properties p = new Properties();
-    final File propertiesFile = new File(properties);
-    if (propertiesFile.exists() == false)
-    {
+    final File propertiesFile = new File( properties );
+    if ( propertiesFile.exists() == false ) {
       return new HashMap<String, Object>();
     }
 
-    final FileInputStream inStream = new FileInputStream(properties);
-    try
-    {
-      p.load(inStream);
-    }
-    finally
-    {
+    final FileInputStream inStream = new FileInputStream( properties );
+    try {
+      p.load( inStream );
+    } finally {
       inStream.close();
     }
     final HashMap<String, Object> retval = new HashMap<String, Object>();
-    for (final Map.Entry<Object, Object> entry : p.entrySet())
-    {
-      retval.put(String.valueOf(entry.getKey()), entry.getValue());
+    for ( final Map.Entry<Object, Object> entry : p.entrySet() ) {
+      retval.put( String.valueOf( entry.getKey() ), entry.getValue() );
     }
 
     return retval;
   }
 
-  protected void runAllGoldCharts() throws Exception
-  {
+  protected void runAllGoldCharts() throws Exception {
     initializeTestEnvironment();
-    processCharts("cgg");
+    processCharts( "cgg" );
   }
 
-  private void processCharts(final String sourceDirectoryName) throws Exception
-  {
+  private void processCharts( final String sourceDirectoryName ) throws Exception {
     final File marker = findMarker();
-    final File cggCharts = new File(marker, sourceDirectoryName);
-    final File gold = new File(marker, "gold");
+    final File cggCharts = new File( marker, sourceDirectoryName );
+    final File gold = new File( marker, "gold" );
     final FilenameFilter filter = createChartFilter();
 
-    final Map<File, File> files = findFilesToProcess(cggCharts, gold, filter);
+    final Map<File, File> files = findFilesToProcess( cggCharts, gold, filter );
 
-    for (final Map.Entry<File, File> testSpec : files.entrySet())
-    {
+    for ( final Map.Entry<File, File> testSpec : files.entrySet() ) {
       final File file = testSpec.getKey();
       final File goldTargetDirectory = testSpec.getValue();
-      if (file.isDirectory())
-      {
+      if ( file.isDirectory() ) {
         continue;
       }
 
-      try
-      {
-        System.out.printf("Processing %s%n", file);
-        run(file, goldTargetDirectory);
-        System.out.printf("Finished   %s%n", file);
-      }
-      catch (Throwable re)
-      {
-        System.out.printf(re.getMessage());
-        re.printStackTrace(System.out);
-        throw new Exception("Failed at " + file, re);
+      try {
+        System.out.printf( "Processing %s%n", file );
+        run( file, goldTargetDirectory );
+        System.out.printf( "Finished   %s%n", file );
+      } catch ( Throwable re ) {
+        System.out.printf( re.getMessage() );
+        re.printStackTrace( System.out );
+        throw new Exception( "Failed at " + file, re );
       }
     }
   }
 
-  private static Map<File, File> findFilesToProcess(final File cggCharts,
-                                                    final File goldDirectory,
-                                                    final FilenameFilter filter)
-  {
+  private static Map<File, File> findFilesToProcess( final File cggCharts,
+                                                     final File goldDirectory,
+                                                     final FilenameFilter filter ) {
     final Map<File, File> resultFiles = new HashMap<File, File>();
 
-    final File[] files = cggCharts.listFiles(filter);
+    final File[] files = cggCharts.listFiles( filter );
     final HashSet<String> fileSet = new HashSet<String>();
-    for (final File file : files)
-    {
+    for ( final File file : files ) {
       final String fileName = file.getName();
-      if (fileSet.add(fileName.toLowerCase(Locale.ENGLISH)) == false)
-      {
+      if ( fileSet.add( fileName.toLowerCase( Locale.ENGLISH ) ) == false ) {
         // the toy systems MacOS X and Windows use case-insensitive file systems and completely
         // mess up when there are two files with what they consider the same name.
-        throw new IllegalStateException("There is a golden sample with the same Windows/Mac " +
-            "filename in the directory. Make sure your files are unique and lowercase.");
+        throw new IllegalStateException( "There is a golden sample with the same Windows/Mac "
+          + "filename in the directory. Make sure your files are unique and lowercase." );
       }
 
-      if (file.isDirectory())
-      {
-        final File directory = new File(goldDirectory, fileName);
-        final Map<File, File> fromSubDir = findFilesToProcess(file, directory, filter);
-        resultFiles.putAll(fromSubDir);
-      }
-      else
-      {
-        resultFiles.put(file, goldDirectory);
+      if ( file.isDirectory() ) {
+        final File directory = new File( goldDirectory, fileName );
+        final Map<File, File> fromSubDir = findFilesToProcess( file, directory, filter );
+        resultFiles.putAll( fromSubDir );
+      } else {
+        resultFiles.put( file, goldDirectory );
       }
     }
     return resultFiles;
   }
 
-  protected void initializeTestEnvironment() throws Exception
-  {
+  protected void initializeTestEnvironment() throws Exception {
   }
 
-  protected void runSingleGoldChart(final String file) throws Exception
-  {
+  protected void runSingleGoldChart( final String file ) throws Exception {
     initializeTestEnvironment();
 
     final File marker = findMarker();
-    final File gold = new File(marker, "gold");
+    final File gold = new File( marker, "gold" );
 
-    try
-    {
-      final File cggChartFile = findChart(file);
+    try {
+      final File cggChartFile = findChart( file );
 
-      System.out.printf("Processing %s%n", file);
-      run(cggChartFile, gold);
-      System.out.printf("Finished   %s%n", file);
-    }
-    catch (Throwable re)
-    {
-      throw new Exception("Failed at " + file, re);
+      System.out.printf( "Processing %s%n", file );
+      run( cggChartFile, gold );
+      System.out.printf( "Finished   %s%n", file );
+    } catch ( Throwable re ) {
+      throw new Exception( "Failed at " + file, re );
     }
 
-    System.out.println(marker);
+    System.out.println( marker );
   }
 
-  private File findChart(final String file) throws FileNotFoundException
-  {
+  private File findChart( final String file ) throws FileNotFoundException {
     final File marker = findMarker();
-    final File cggCharts = new File(marker, "cgg");
-    final File cggChartFile = new File(cggCharts, file);
-    if (cggChartFile.exists())
-    {
+    final File cggCharts = new File( marker, "cgg" );
+    final File cggChartFile = new File( cggCharts, file );
+    if ( cggChartFile.exists() ) {
       return cggChartFile;
     }
 
-    throw new FileNotFoundException(file);
+    throw new FileNotFoundException( file );
   }
 
-  protected FilenameFilter createChartFilter()
-  {
-    return new FilesystemFilter(new String[]{"-svg-test.js", "-j2d-test.js"}, "Test scripts", true);
+  protected FilenameFilter createChartFilter() {
+    return new FilesystemFilter( new String[] { "-svg-test.js", "-j2d-test.js" }, "Test scripts", true );
   }
 
-  public static File locateGoldenSample(final String name)
-  {
-    final FilesystemFilter filesystemFilter = new FilesystemFilter(name, "Charts", true);
+  public static File locateGoldenSample( final String name ) {
+    final FilesystemFilter filesystemFilter = new FilesystemFilter( name, "Charts", true );
     final File marker = findMarker();
-    final File gold = new File(marker, "gold");
-    final File cggCharts = new File(marker, "cggCharts");
-    final Map<File, File> files = findFilesToProcess(cggCharts, gold, filesystemFilter);
+    final File gold = new File( marker, "gold" );
+    final File cggCharts = new File( marker, "cggCharts" );
+    final Map<File, File> files = findFilesToProcess( cggCharts, gold, filesystemFilter );
 
     //noinspection LoopStatementThatDoesntLoop
-    for (final Map.Entry<File, File> fileFileEntry : files.entrySet())
-    {
+    for ( final Map.Entry<File, File> fileFileEntry : files.entrySet() ) {
       return fileFileEntry.getKey();
     }
 
     return null;
   }
 
-  protected void handleContent(final byte[] cggChartOutput,
-                               final File goldSample,
-                               final String outputType) throws Exception
-  {
-    
-    FileOutputStream fos = new FileOutputStream(goldSample.getName());
+  protected void handleContent( final byte[] cggChartOutput,
+                                final File goldSample,
+                                final String outputType ) throws Exception {
 
-    fos.write(cggChartOutput);  
-    
-    if ("svg".equals(outputType))
-    {
-      final Reader reader = new InputStreamReader(new FileInputStream(goldSample), CharsetHelper.getEncoding());
-      final ByteArrayInputStream inputStream = new ByteArrayInputStream(cggChartOutput);
-      final Reader cggChart = new InputStreamReader(inputStream, CharsetHelper.getEncoding());
-      try
-      {
-        XMLAssert.assertXMLEqual("File " + goldSample + " failed", new Diff(reader, cggChart), true);
+    FileOutputStream fos = new FileOutputStream( goldSample.getName() );
+
+    fos.write( cggChartOutput );
+
+    if ( "svg".equals( outputType ) ) {
+      final Reader reader = new InputStreamReader( new FileInputStream( goldSample ), CharsetHelper.getEncoding() );
+      final ByteArrayInputStream inputStream = new ByteArrayInputStream( cggChartOutput );
+      final Reader cggChart = new InputStreamReader( inputStream, CharsetHelper.getEncoding() );
+
+      // writes the file to check what is the result even if the tests fail
+      final FileInputStream in = new FileInputStream( goldSample );
+      try {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOUtils.copy( in, out );
+      } finally {
+        in.close();
       }
-      catch (AssertionFailedError afe)
-      {
+
+      try {
+        Diff differences = new Diff( cggChart, reader );
+        differences.overrideDifferenceListener( new DifferenceListener() {
+          @Override
+          public int differenceFound( Difference difference ) {
+            NodeDetail controlNode = difference.getControlNodeDetail(),
+                testNode = difference.getTestNodeDetail();
+            String controlNodeValue = controlNode.getValue(),
+                testNodeValue = testNode.getValue();
+
+            if ( difference.getId() == DifferenceConstants.ATTR_VALUE_ID ) {
+              return checkDifferenceInValueAttribute( controlNodeValue, testNodeValue );
+            } else if ( difference.getId() == DifferenceConstants.ELEMENT_NUM_ATTRIBUTES_ID
+                || difference.getId() == DifferenceConstants.ATTR_NAME_NOT_FOUND_ID ) {
+              return checkDifferenceNodeProperties( controlNode, testNode );
+            }
+            return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+          }
+
+          @Override
+          public void skippedComparison( Node node, Node node1 ) {
+          }
+        } );
+        differences.identical();
+        XMLAssert.assertXMLEqual( "File " + goldSample + " failed", differences, true );
+      } catch ( AssertionFailedError afe ) {
         throw afe;
-      }
-      finally
-      {
+      } finally {
         reader.close();
       }
     }
+  }
 
-    final FileInputStream in = new FileInputStream(goldSample);
-    try
-    {
-      final ByteArrayOutputStream out = new ByteArrayOutputStream();
-      IOUtils.copy(in, out);
-      Assert.assertArrayEquals(out.toByteArray(), cggChartOutput);
+  private Integer checkDifferenceNodeProperties( NodeDetail controlNode, NodeDetail testNode ) {
+    Node node = testNode.getNode().getAttributes().getNamedItem( TRANSFORM_ATTRIBUTE );
+    Pattern pTranslate = Pattern.compile( TRANSLATE_REGEX );
+
+    Matcher mTestNode = pTranslate.matcher( node.getNodeValue() );
+
+    if ( mTestNode.matches() ) {
+      String[] valueSplit = mTestNode.group( 1 ).split( "," );
+      Double x = new Double( valueSplit[ 0 ] ), y = new Double( valueSplit[ 1 ] );
+
+      if ( x < VALUE_MIN && y < VALUE_MIN ) {
+        return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+      }
     }
-    finally
-    {
-      in.close();
+    return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+  }
+
+  private Integer checkDifferenceInValueAttribute( String controlNodeValue, String testNodeValue ) {
+    Pattern pTranslate = Pattern.compile( TRANSLATE_REGEX );
+    Matcher mControlNode = pTranslate.matcher( controlNodeValue ),
+        mTestNode = pTranslate.matcher( testNodeValue );
+
+    if ( mControlNode.matches() && mTestNode.matches() ) {
+      return checkTranslatePositions( mControlNode.group( 1 ), mTestNode.group( 1 ) );
+    } else if ( NumberUtils.isNumber( controlNodeValue ) && NumberUtils.isNumber( testNodeValue ) ) {
+      return checkValueDifference( controlNodeValue, testNodeValue );
+    } else {
+      return checkPath( controlNodeValue, testNodeValue );
     }
   }
 
+  private Integer checkTranslatePositions( String controlNodeValue, String testNodeValue ) {
+    String[] controlNodeValues = controlNodeValue.split( "," ),
+        testNodeValues = testNodeValue.split( "," );
 
-  public static File findMarker()
-  {
+    Double x1 = new Double( controlNodeValues[ 0 ] ), x2 = new Double( testNodeValues[ 0 ] ),
+        y1 = new Double( controlNodeValues[ 1 ] ), y2 = new Double( testNodeValues[ 1 ] );
+
+    if ( Math.sqrt( ( ( x2 - x1 ) * ( x2 - x1 ) ) + ( ( y2 - y1 ) * ( y2 - y1 ) ) ) <= MIN_PIXEL_DIFFERENCE ) {
+      return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+    }
+    return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+  }
+
+  private Integer checkValueDifference( String controlNodeValue, String testNodeValue ) {
+    Double v1 = new Double( controlNodeValue ), v2 = new Double( testNodeValue );
+
+    if ( Math.abs( v1 - v2 ) < MIN_PIXEL_DIFFERENCE ) {
+      return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+    }
+    return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+  }
+
+  private Integer checkPath( String controlNodeValue, String testNodeValue ) {
+    String[] parts1 = controlNodeValue.split( PATH_REGEX ), parts2 = testNodeValue.split( PATH_REGEX );
+
+    for ( int i = 1; i < parts1.length; i++ ) {
+      Double v1 = new Double( parts1[i] ),
+          v2 = new Double( parts2[i] );
+
+      if ( ( Math.abs( v1 - v2 ) / ( ( v1 + v2 ) / 2 ) ) * 100 < 5 ) {
+        return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+      } else {
+        return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+      }
+    }
+    return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
+  }
+
+
+  public static File findMarker() {
     final ArrayList<String> positions = new ArrayList<String>();
-    positions.add("test-gold/marker.properties");
-    for (final String pos : positions)
-    {
-      final File file = checkMarkerExists(pos);
-      if (file != null)
-      {
+    positions.add( "test-gold/marker.properties" );
+    for ( final String pos : positions ) {
+      final File file = checkMarkerExists( pos );
+      if ( file != null ) {
         return file.getAbsoluteFile().getParentFile();
       }
     }
-    throw new IllegalStateException("Cannot find marker, please run from the correct directory");
+    throw new IllegalStateException( "Cannot find marker, please run from the correct directory" );
   }
 
 }

--- a/cgg-pentaho5/ivy.xml
+++ b/cgg-pentaho5/ivy.xml
@@ -5,8 +5,8 @@
 
   <configurations>
     <conf name="default"/>
-	<conf name="source"/>
-	<conf name="zip"/>
+    <conf name="source"/>
+    <conf name="zip"/>
     <conf name="test" visibility="private"/>
     <conf name="codegen" visibility="private"/>
     <conf name="runtime" visibility="private"/>
@@ -18,7 +18,7 @@
   <publications>
     <artifact name="${ivy.artifact.id}" type="jar" conf="default" />
     <artifact name="${ivy.artifact.id}" type="zip" conf="zip" />
-	<artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar" conf="source"/>
+    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar" conf="source"/>
   </publications>
 
   <dependencies defaultconf="default->default">
@@ -27,25 +27,24 @@
     <dependency org="commons-logging"        name="commons-logging"     rev="1.1.1" transitive="false"/>
     <dependency org="dom4j"                  name="dom4j"               rev="1.6.1" transitive="false"/>
     <dependency org="commons-lang"           name="commons-lang"        rev="2.2"/>
-	  <dependency org="javax.servlet"          name="servlet-api"         rev="2.4" />
-	  <dependency org="xml-apis"               name="xml-apis-ext"        rev="1.3.04"/>
-	  <dependency org="rhino"                  name="js"                  rev="1.7R1" />
+    <dependency org="javax.servlet"          name="servlet-api"         rev="2.4" />
+    <dependency org="xml-apis"               name="xml-apis-ext"        rev="1.3.04"/>
+    <dependency org="rhino"                  name="js"                  rev="1.7R3" />
     <dependency org="org.apache.xmlgraphics" name="xmlgraphics-commons" rev="1.2" transitive="false"/>
     <dependency org="javax.ws.rs"            name="jsr311-api"          rev="1.0"/>
 
 
     <!--  pentaho dependencies -->
-	<!-- pentaho-bi-platform-plugin-services pulls js-1.7R1 -->
-	  <dependency org="pentaho" name="mondrian"                          rev="3.5.4"                               transitive="false" changing="true"/>
+    <!-- pentaho-bi-platform-plugin-services pulls js-1.7R3 -->
+    <dependency org="pentaho" name="mondrian"                          rev="3.5.4"                               transitive="false" changing="true"/>
     <dependency org="pentaho" name="pentaho-platform-api"              rev="${dependency.bi-platform.revision}"  transitive="false" changing="true"/>
     <dependency org="pentaho" name="pentaho-platform-core"             rev="${dependency.bi-platform.revision}"  transitive="false" changing="true"/>
     <dependency org="pentaho" name="pentaho-platform-repository"       rev="${dependency.bi-platform.revision}"  transitive="false" changing="true"/>
     <dependency org="pentaho" name="pentaho-platform-extensions"       rev="${dependency.bi-platform.revision}"  transitive="false" changing="true"/>
 
-
     <!-- runtime dependencies -->
     <!--  runtime batik -->
-	  <dependency org="org.apache.xmlgraphics"      name="batik-awt-util"        rev="${batik.rev}"                              conf='runtime->default' transitive="false"/>
+    <dependency org="org.apache.xmlgraphics"      name="batik-awt-util"        rev="${batik.rev}"                              conf='runtime->default' transitive="false"/>
     <dependency org="org.apache.xmlgraphics"      name="batik-anim"            rev="${batik.rev}"                              conf='runtime->default' transitive="false"/>
     <dependency org="org.apache.xmlgraphics"      name="batik-css"             rev="${batik.rev}"                              conf='runtime->default' transitive="false"/>
     <dependency org="org.apache.xmlgraphics"      name="batik-codec"           rev="${batik.rev}"                              conf='runtime->default' transitive="false"/>
@@ -75,15 +74,10 @@
     <dependency org="pentaho"                     name="cpf-pentaho5"          rev="${dependency.pentaho-cpf-plugin.revision}" conf='runtime->default' transitive="false" changing="true"/>
     <dependency org="pentaho"                     name="cgg-core"              rev="${project.revision}"                       conf='runtime->default' transitive="false" changing="true"/>
 
-
-
-
     <!--  codegen dependencies -->
     <dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="${batik.rev}" conf='codegen->default' transitive="false"/>
     <dependency org="org.apache.xmlgraphics" name="batik-dom"      rev="${batik.rev}" conf='codegen->default' transitive="false"/>
     <dependency org="org.apache.xmlgraphics" name="batik-svggen"   rev="${batik.rev}" conf='codegen->default' transitive="false"/>
-
-
 
   </dependencies>
 


### PR DESCRIPTION
 - Fixed cgg tests way to check if a cgg generation is invalid or not analysing the differences between the generated svg and the control one
 - Updated control svg files due to wrong stroke-width property
 - Updated rhino lib accordingly with what is used in the platform
 - Reenabled the unit test
 - Added clean-all target override to force the js-lib cleanup