### PR TITLE
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/cgg-core/build.properties
+++ b/cgg-core/build.properties
@@ -27,6 +27,6 @@ java.awt.headless=true
 project.use-external-libdir=true
 project.use-full-dist=true
 ivy.default.sub-configs=internal,external
-batik.rev=1.7
+batik.rev=1.7.1
 dependency.pentaho-cpf-plugin.revision=6.1-SNAPSHOT
 dependency.pentaho-ccc-plugin.revision=6.1-SNAPSHOT

--- a/cgg-pentaho/build.properties
+++ b/cgg-pentaho/build.properties
@@ -13,7 +13,7 @@ testsrc.dir=test
 dependency.bi-platform.revision=6.1-SNAPSHOT
 #dependency.json.revision=3.1
 dependency.pentaho-connections.revision=6.1-SNAPSHOT
-batik.rev=1.7
+batik.rev=1.7.1
 
 dependency.pentaho-cpf-plugin.revision=6.1-SNAPSHOT
 

--- a/cgg-pentaho5/build.properties
+++ b/cgg-pentaho5/build.properties
@@ -12,7 +12,7 @@ impl.title=Community Graphics Generator
 dependency.bi-platform.revision=6.1-SNAPSHOT
 #dependency.json.revision=3.1
 dependency.pentaho-connections.revision=6.1-SNAPSHOT
-batik.rev=1.7
+batik.rev=1.7.1
 
 dependency.pentaho-cpf-plugin.revision=6.1-SNAPSHOT
 dependency.mondrian.revision=3.12-SNAPSHOT

--- a/cgg-reporting/build.properties
+++ b/cgg-reporting/build.properties
@@ -27,4 +27,4 @@ java.awt.headless=true
 project.use-external-libdir=true
 project.use-full-dist=true
 ivy.default.sub-configs=internal,external
-batik.rev=1.7
+batik.rev=1.7.1


### PR DESCRIPTION
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (6.1 Suite)