### PR TITLE
[BACKLOG-14077] 

### DIFF
--- a/cgg-core/src/pt/webdetails/cgg/resources/define-cfg.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/define-cfg.js
@@ -138,7 +138,7 @@
     packages: [],
     config: {
       "pentaho/service": {
-        "pentaho/visual/config/vizApi.views.conf": "pentaho.config.spec.IRuleSet",
+        "pentaho/visual/config/vizApi.conf": "pentaho.config.spec.IRuleSet",
         "pentaho/config/impl/instanceOfAmdLoadedService": "pentaho.config.IService"
       },
 


### PR DESCRIPTION
 - Align config file name with the common-ui change

