### PR TITLE
[BACKLOG-14077] 

### DIFF
--- a/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/ccc/SvgComponent.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/ccc/SvgComponent.js
@@ -70,6 +70,11 @@ define([
         cd = $.extend(externalChartDefinition, cd);
       }
 
+      // special case for this array which $.extend does not smash
+      if (cd.baseAxisLabelDesiredAngles && cd.baseAxisLabelDesiredAngles.length == 0) {
+        cd.baseAxisLabelDesiredAngles = undefined;
+      }
+
       this.width = +cd.width || +this.width;
       this.height = +cd.height || +this.height;
       this.noChartBg = cgg.params.get('noChartBg') === 'true';


### PR DESCRIPTION
 - Added special case for an array property, which should be smashed if the array is empty. This will be reviewed if we have more properties like this in the future

@pamval @afrjorge @dcleao please review