### PR TITLE
[BACKLOG-15553] PAZ: Charts - Export to PDF is not working

### DIFF
--- a/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/ccc/BaseCccComponent.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/cdf/components/ccc/BaseCccComponent.js
@@ -61,11 +61,6 @@ define([
         global.pvc = pvc;
       }
 
-      define("cdf/lib/CCC/def",      function() { return def; });
-      define("cdf/lib/CCC/cdo",      function() { return ccc.cdo; });
-      define("cdf/lib/CCC/pvc",      function() { return pvc; });
-      define("cdf/lib/CCC/protovis", function() { return pv;  });
-
       // Sync def/pvc log, taking older ccc versions into account.
       if (def.setDebug) def.setDebug(cgg.debug);
       else if (pvc.setDebug) pvc.setDebug(cgg.debug);

--- a/cgg-core/src/pt/webdetails/cgg/resources/define.js
+++ b/cgg-core/src/pt/webdetails/cgg/resources/define.js
@@ -360,10 +360,7 @@
     // Configs - Map of "absolute module id" to configuration value.
     var configs = config.config;
     for(amid in configs) {
-      var cfg = configs[amid];
-      if(cfg != null) {
-        this.get(amid, true).configConfig(cfg);
-      }
+      this.get(amid, true).configConfig(configs[amid]);
     }
 
     DEBUG && print("END configure");
@@ -407,6 +404,19 @@
   };
 
   Module.prototype.configConfig = function(config) {
+    var configOld = this.config.config;
+
+    if(config != null &&
+        configOld != null &&
+        typeof config === "object" &&
+        typeof configOld === "object") {
+      // Merge top-level
+      for(var p in config) {
+        configOld[p] = config[p];
+      }
+      return;
+    }
+
     this.config.config = config;
   };
 

--- a/cgg-pentaho5/src/pt/webdetails/cgg/CggService.java
+++ b/cgg-pentaho5/src/pt/webdetails/cgg/CggService.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
@@ -46,6 +47,7 @@ public class CggService {
 
   private static final String CCC_VERSION_PARAM = "cccVersion";
   private static final String CCC_MULTICHART_OVERFLOW_PARAM = "multiChartOverflow";
+  private static final String CONTEXT_PATH_PARAM = "CONTEXT_PATH";
 
   private static final Log logger = LogFactory.getLog( CggService.class );
   private OutputStream outputStream;
@@ -136,6 +138,11 @@ public class CggService {
       if ( !StringUtils.isEmpty( cccLibVersion ) ) {
         params.put( CCC_VERSION_PARAM, cccLibVersion );
       }
+
+      // e.g. "http://my-server:8080/pentaho/"
+      String serverURL = PentahoSystem.getApplicationContext().getFullyQualifiedServerURL();
+      // e.g. "/pentaho/"
+      params.put( CONTEXT_PATH_PARAM, new URL( serverURL ).getPath() );
 
       //Ensure script begins with /
       if ( !script.startsWith( "/" ) ) {

--- a/cgg-pentaho5/src/pt/webdetails/cgg/scripts/WebResourceLoader.java
+++ b/cgg-pentaho5/src/pt/webdetails/cgg/scripts/WebResourceLoader.java
@@ -28,8 +28,6 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 
 import java.nio.charset.StandardCharsets;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class WebResourceLoader implements ScriptResourceLoader {
   private static final Log logger = LogFactory.getLog( WebResourceLoader.class );
@@ -66,26 +64,24 @@ public class WebResourceLoader implements ScriptResourceLoader {
     try {
       String url = script;
 
-      // e.g. "http://my-server:8080/pentaho/"
-      String serverURL = PentahoSystem.getApplicationContext().getFullyQualifiedServerURL();
-      // e.g. "/pentaho/"
-      String contextPath = new URL( serverURL ).getPath();
-      // e.g. "http://my-server:8080"
-      String baseURL = serverURL.substring( 0, serverURL.length() - contextPath.length() );
-
-      String regex = "^(.[^\\?]*)\\?plugin=\\&name=plugin\\/(.[^\\/]*)(.*)$";
-      Matcher m = Pattern.compile( regex ).matcher( script );
-      if ( m.matches() ) {
-        url = m.group( 1 ).replace( "${CONTEXT_PATH}", baseURL + contextPath )
-            + "?plugin=" + m.group( 2 )
-            + "&name=" + m.group( 3 ).substring( 1, m.group( 3 ).length() );
-      } else if ( url.startsWith( "/" ) ) {
-        url = baseURL + url;
-      }
-
       if ( this.userName != null ) {
         url = url + ( url.contains( "?" ) ? "&" : "?" )
-            + URL_PARAM_USER + "=" + URLEncoder.encode( this.userName, StandardCharsets.UTF_8.name() );
+          + URL_PARAM_USER + "=" + URLEncoder.encode( this.userName, StandardCharsets.UTF_8.name() );
+      }
+
+      // Paths already contain contextPath.
+      // e.g. "/pentaho/foo/bar"
+      if ( url.startsWith( "/" ) ) {
+        // e.g. "http://my-server:8080/pentaho/"
+        String serverURL = PentahoSystem.getApplicationContext().getFullyQualifiedServerURL();
+
+        // e.g. "/pentaho/"
+        String contextPath = new URL( serverURL ).getPath();
+
+        // e.g. "http://my-server:8080"
+        String baseURL = serverURL.substring( 0, serverURL.length() - contextPath.length() );
+
+        url = baseURL + url;
       }
 
       URLConnection connection = new URL( url ).openConnection();


### PR DESCRIPTION
* Merged two groups of AMD configurations in define-cfg.js
* Removed the suspicious “cdf/lib/CCC” to “ccc” mapping in define-cfg.js, as we’re defining modules to map the other way around
* Moved “cdf/lib/CCC/*” module definitions to define-cfg.js, so these aliases can be used from any print scripts
* Fixed define.js to merge the top-level of module configurations (configuring multiple times was overwriting previous configurations)
* Added the CONTEXT_PATH parameter to the global `params` (the old ${CONTEXT_PATH}` replace method was failing somehow) and reverted related changes to `WebResourceLoader`
* Refactored and fixed the loading of `/system` and `/plugin` resources - it was only working for print scripts whose `basePath` was not within `/system` (and Analyzer’s are).

@pentaho/millenniumfalcon, @davidmsantos90, @carlosrusso, @nantunes, @dmariano please review.

See main PR: https://github.com/pentaho/pentaho-analyzer/pull/1458