### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,15 +173,15 @@
       <artifactId>xalan</artifactId>
       <version>${xalan.version}</version>
       <scope>provided</scope>
-   </dependency>
+    </dependency>
 
-   <dependency>  
+    <dependency>
       <groupId>xerces</groupId> 
       <artifactId>xercesImpl</artifactId>   
       <scope>provided</scope>   
-   </dependency>
+    </dependency>
 
-   <dependency>
+    <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis-ext</artifactId>
       <version>1.3.04</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,14 +173,15 @@
       <artifactId>xalan</artifactId>
       <version>${xalan.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
+   </dependency>
+
+   <dependency>  
+      <groupId>xerces</groupId> 
+      <artifactId>xercesImpl</artifactId>   
+      <scope>provided</scope>   
+   </dependency>
+
+   <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis-ext</artifactId>
       <version>1.3.04</version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-lang.version>2.6</commons-lang.version>
     <xalan.version>2.7.1</xalan.version>
-    <xercesImpl.version>2.9.1</xercesImpl.version>
     <pentaho-cgg-plugin.version>8.3.0.0-SNAPSHOT</pentaho-cgg-plugin.version>
     <mail.version>1.4.1</mail.version>
     <javax.servlet-api>3.0.1</javax.servlet-api>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 