### PR TITLE
[BACKLOG-30893] Centralize commons-logging in parent pom

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/pentaho/pom.xml
+++ b/pentaho/pom.xml
@@ -26,6 +26,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <batik.version>1.9.1</batik.version>
     <pentaho-cpf-plugin.version>9.0.0.0-SNAPSHOT</pentaho-cpf-plugin.version>
     <platform.version>9.0.0.0-SNAPSHOT</platform.version>
-    <commons-logging.version>1.1.1</commons-logging.version>
     <commons-lang.version>2.6</commons-lang.version>
     <xalan.version>2.7.1</xalan.version>
     <pentaho-cgg-plugin.version>9.0.0.0-SNAPSHOT</pentaho-cgg-plugin.version>
@@ -81,12 +80,6 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
Linked with this: pentaho/maven-parent-poms#163