### PR TITLE
[ANALYZER-3942] Fixed empty npm.version in pom, which com.pentaho.VersionMerger does not like

### DIFF
--- a/js-intl-polyfill/pom.xml
+++ b/js-intl-polyfill/pom.xml
@@ -12,12 +12,13 @@
   </parent>
 
   <artifactId>cgg-js-intl-polyfill</artifactId>
-  <packaging>pom</packaging>
   <version>9.3.0.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
 
   <properties>
     <nodejs.version>v14.17.0</nodejs.version>
-    <npm.version/>
+    <npm.version>6.14.13</npm.version>
     <frontend-maven-plugin.workingDirectory>${project.basedir}</frontend-maven-plugin.workingDirectory>
     <frontend-maven-plugin.installDirectory>${project.build.directory}</frontend-maven-plugin.installDirectory>
   </properties>


### PR DESCRIPTION
- The empty pom would achieve not having to separately install npm, given that since version 4, node already comes with npm; this way, we install npm twice, but at least com.pentaho.VersionMerger is happy with it

/cc @srini-hv