### PR TITLE
[ANALYZER-3942] When getting Pentaho web resources, use the current effective locale, not the override.

### DIFF
--- a/core/src/main/javascript/pt/webdetails/cgg/resources/timer.js
+++ b/core/src/main/javascript/pt/webdetails/cgg/resources/timer.js
@@ -39,7 +39,7 @@
                 try {
                     task.fun.apply(null, task.args);
                 } catch(ex) {
-                    print("ERROR - setTimeout: " + ex);
+                    print("ERROR - setTimeout: " + ex.message + ":\n" + ex.stack);
                 }
             }
         }

--- a/pentaho/src/main/java/pt/webdetails/cgg/scripts/WebResourceLoader.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/scripts/WebResourceLoader.java
@@ -71,10 +71,10 @@ public class WebResourceLoader implements ScriptResourceLoader {
         url = url + ( url.contains( "?" ) ? "&" : "?" )
           + URL_PARAM_USER + "=" + URLEncoder.encode( this.userName, StandardCharsets.UTF_8.name() );
 
-        Locale localeOverride = LocaleHelper.getLocaleOverride();
-        if ( localeOverride != null ) {
+        Locale locale = LocaleHelper.getLocale();
+        if ( locale != null ) {
           url = url + "&" + URL_PARAM_LOCALE_OVERRIDE + "="
-              + URLEncoder.encode( localeOverride.toString(), StandardCharsets.UTF_8.name() );
+              + URLEncoder.encode( locale.toString(), StandardCharsets.UTF_8.name() );
         }
       }
 


### PR DESCRIPTION
Make sure to send the _current locale_, and not only the _session locale override_, when requesting resources from CGG, so that the request locale is preserved.

@bennychow please review.

This PR is to be merged along with https://github.com/pentaho/pentaho-platform/pull/4904