### PR TITLE
[BACKLOG-41287]-Upgrading cgg from Java EE to Jakarta EE to support with Tomcat-10.X

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -247,9 +247,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>${mail.version}</version>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+      <version>${jakarta.mail.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/pt/webdetails/cgg/SVGChart.java
+++ b/core/src/main/java/pt/webdetails/cgg/SVGChart.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ * Copyright 2002 - 2024 Webdetails, a Hitachi Vantara company.  All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -30,11 +30,11 @@ import pt.webdetails.cgg.output.PngOutputHandler;
 import pt.webdetails.cgg.output.SVGOutputHandler;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
-import javax.activation.DataHandler;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
+import jakarta.activation.DataHandler;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 
 /**
  * @author pdpi

--- a/pentaho/pom.xml
+++ b/pentaho/pom.xml
@@ -34,15 +34,15 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${javax.servlet-api}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>1.0</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs-api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pentaho/src/main/java/pt/webdetails/cgg/CggContentGenerator.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/CggContentGenerator.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2024 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -14,8 +14,8 @@
 package pt.webdetails.cgg;
 
 import java.io.OutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/pentaho/src/main/java/pt/webdetails/cgg/CggService.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/CggService.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company.  All rights reserved.
+ * Copyright 2002 - 2024 Webdetails, a Hitachi Vantara company.  All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -23,17 +23,17 @@ import pt.webdetails.cgg.scripts.ScriptResourceNotFoundException;
 import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.OutputStream;
 import java.net.URL;
@@ -42,8 +42,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
 
 @Path( "/cgg/api/services" )
 public class CggService {

--- a/pentaho/src/main/java/pt/webdetails/cgg/WebCgg.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/WebCgg.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company.  All rights reserved.
+* Copyright 2002 - 2024 Webdetails, a Hitachi Vantara company.  All rights reserved.
 *
 * This software was developed by Webdetails and is provided under the terms
 * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -15,7 +15,7 @@ package pt.webdetails.cgg;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import pt.webdetails.cgg.datasources.WebDataSourceFactory;
 import pt.webdetails.cgg.output.OutputHandler;

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
     <commons-lang.version>2.6</commons-lang.version>
     <xalan.version>2.7.1</xalan.version>
     <pentaho-cgg-plugin.version>10.3.0.0-SNAPSHOT</pentaho-cgg-plugin.version>
-    <mail.version>1.4.1</mail.version>
-    <javax.servlet-api>3.0.1</javax.servlet-api>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading cgg from Java EE to Jakarta EE to support with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ