### PR TITLE
[SP-6638] Backport of PPP-4998 - CGG draw API allows access to local …

### DIFF
--- a/core/src/main/java/pt/webdetails/cgg/scripts/BaseScript.java
+++ b/core/src/main/java/pt/webdetails/cgg/scripts/BaseScript.java
@@ -131,10 +131,9 @@ public abstract class BaseScript implements Script {
 
     try {
       scope.loadScript( cx, source );
-    } catch ( ScriptResourceNotFoundException e ) {
+    } catch ( ScriptResourceNotFoundException | IOException e ) {
       logger.error( "Failed to read " + source + ": " + e.toString(), e );
-    } catch ( IOException e ) {
-      logger.error( "Failed to read " + source + ": " + e.toString(), e );
+      throw new ScriptExecuteException( e );
     }
   }
 }

--- a/pentaho/src/main/java/pt/webdetails/cgg/scripts/JCRScriptResourceLoader.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/scripts/JCRScriptResourceLoader.java
@@ -62,6 +62,9 @@ public class JCRScriptResourceLoader implements ScriptResourceLoader {
     }
     UserContentRepositoryAccess repositoryAccess = new UserContentRepositoryAccess( PentahoSessionHolder.getSession(),
       s.startsWith( "/" ) ? null : basePath );
+    if ( !repositoryAccess.fileExists( s ) ) {
+      throw new ScriptResourceNotFoundException( s );
+    }
     return repositoryAccess.getFileInputStream( s );
   }
 

--- a/pentaho/src/main/java/pt/webdetails/cgg/scripts/SystemFolderScriptResourceLoader.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/scripts/SystemFolderScriptResourceLoader.java
@@ -86,9 +86,19 @@ public class SystemFolderScriptResourceLoader implements ScriptResourceLoader {
       fullPath = StringUtils.join( sections, "/" );
     }
 
-    SystemPluginResourceAccess resourceAccess = new SystemPluginResourceAccess( plugin, "" );
+    SystemPluginResourceAccess resourceAccess;
+    try{
+      resourceAccess = new SystemPluginResourceAccess( plugin, "" );
+    } catch (IllegalArgumentException e ){
+      throw new ScriptResourceNotFoundException( fullPath, e );
+    }
 
-    return resourceAccess.getFileInputStream( fullPath );
+    InputStream inputStream = resourceAccess.getFileInputStream( fullPath );
+    if (inputStream == null){
+      throw new ScriptResourceNotFoundException( fullPath );
+    }
+
+    return inputStream;
   }
 
   public InputStream getWebResource( String script ) throws IOException, ScriptResourceNotFoundException {


### PR DESCRIPTION
…file system (10.2 Suite)

[PPP-4998] CGG draw API allows access to local file system
- Restrict access to local filesystem by normalizing paths to the "root" of script loaders, not the local filesystem
- Propagate script execution errors and set the appropriate HTTP status code, as before, all authorized requests were returning 200

[PPP-4998]: https://hv-eng.atlassian.net/browse/PPP-4998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ