### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -247,9 +247,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>${mail.version}</version>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+      <version>${jakarta.mail.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/pt/webdetails/cgg/SVGChart.java
+++ b/core/src/main/java/pt/webdetails/cgg/SVGChart.java
@@ -30,11 +30,11 @@ import pt.webdetails.cgg.output.PngOutputHandler;
 import pt.webdetails.cgg.output.SVGOutputHandler;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
-import javax.activation.DataHandler;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
+import jakarta.activation.DataHandler;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 
 /**
  * @author pdpi

--- a/pentaho/pom.xml
+++ b/pentaho/pom.xml
@@ -34,15 +34,15 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${javax.servlet-api}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>1.0</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs-api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pentaho/src/main/java/pt/webdetails/cgg/CggContentGenerator.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/CggContentGenerator.java
@@ -14,8 +14,8 @@
 package pt.webdetails.cgg;
 
 import java.io.OutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/pentaho/src/main/java/pt/webdetails/cgg/CggService.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/CggService.java
@@ -23,17 +23,17 @@ import pt.webdetails.cgg.scripts.ScriptResourceNotFoundException;
 import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.OutputStream;
 import java.net.URL;
@@ -42,8 +42,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
 
 @Path( "/cgg/api/services" )
 public class CggService {

--- a/pentaho/src/main/java/pt/webdetails/cgg/WebCgg.java
+++ b/pentaho/src/main/java/pt/webdetails/cgg/WebCgg.java
@@ -15,7 +15,7 @@ package pt.webdetails.cgg;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import pt.webdetails.cgg.datasources.WebDataSourceFactory;
 import pt.webdetails.cgg.output.OutputHandler;

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
     <commons-lang.version>2.6</commons-lang.version>
     <xalan.version>2.7.1</xalan.version>
     <pentaho-cgg-plugin.version>11.0.0.0-SNAPSHOT</pentaho-cgg-plugin.version>
-    <mail.version>1.4.1</mail.version>
-    <javax.servlet-api>3.0.1</javax.servlet-api>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This pull request updates the project to use the `jakarta` namespace for dependencies and imports, replacing the deprecated `javax` namespace. This change aligns the codebase with modern Java standards and ensures compatibility with newer versions of libraries.

### Dependency Updates:
* Updated the `pom.xml` files to replace `javax.mail` with `jakarta.mail` and `javax.servlet` with `jakarta.servlet`. Additionally, replaced `javax.ws.rs` with `jakarta.ws.rs`. These changes include updating the group IDs, artifact IDs, and version properties. (`core/pom.xml` - [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcL250-R252) `pentaho/pom.xml` - [[2]](diffhunk://#diff-6d1d91052865bf2ef5f1f522f5ebcdf632fb000f74a2dd31a885b958252b8cf0L37-R45) `pom.xml` - [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L45-L46)

### Import Updates:
* Replaced `javax` imports with `jakarta` imports in multiple Java files to reflect the dependency changes:
  - [`SVGChart.java`](diffhunk://#diff-7bbff2531db0cd5f1f3f4887e8f7d00cdae39d829337f2d7dee592b60b6d9783L33-R37): Updated imports for `DataHandler`, `MessagingException`, `MimeBodyPart`, `MimeMultipart`, and `ByteArrayDataSource`.
  - [`CggContentGenerator.java`](diffhunk://#diff-85c0e169e7d092dccf235ea694bffc3c22b46e433f794fa497228ee448cb9986L17-R18): Updated imports for `HttpServletRequest` and `HttpServletResponse`.
  - [`CggService.java`](diffhunk://#diff-1872219d1f00fe217460b84f13fb43ba50cabb976528a75163dd6170747e3c30L26-R36): Updated imports for `ServletResponse`, `HttpServletRequest`, `HttpServletResponse`, and `javax.ws.rs` classes (e.g., `Consumes`, `GET`, `Produces`). Also updated static imports for media types. [[1]](diffhunk://#diff-1872219d1f00fe217460b84f13fb43ba50cabb976528a75163dd6170747e3c30L26-R36) [[2]](diffhunk://#diff-1872219d1f00fe217460b84f13fb43ba50cabb976528a75163dd6170747e3c30L45-R46)
  - [`WebCgg.java`](diffhunk://#diff-d2defece26b482879b4ce390bd6d11e93316c345662b75ea20a3a4a03575c7faL18-R18): Updated import for `HttpServletResponse`.