### PR TITLE
fix[ANALYZER-4195]: restore analyzer date axis rounding without global UTC side effects

### DIFF
--- a/core/src/main/java/pt/webdetails/cgg/scripts/AbstractScriptFactory.java
+++ b/core/src/main/java/pt/webdetails/cgg/scripts/AbstractScriptFactory.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -33,10 +32,6 @@ public abstract class AbstractScriptFactory implements ScriptFactory {
   private HashMap<ScriptType, BaseScope> contexts;
 
   protected AbstractScriptFactory() {
-    // Force UTC timezone for JavaScript date parsing.
-    // This prevents dates from being shifted by local timezone offset.
-    TimeZone.setDefault( TimeZone.getTimeZone( "UTC" ) );
-
     contextFactory = new ContextFactory();
     contexts = new HashMap<>();
   }

--- a/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/main.js
+++ b/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/main.js
@@ -16,12 +16,8 @@ define([
     './protovis',
     './pvc'
 ], function(cgg, pv, pvc) {
-    // Let cgg init, as well.
-    cgg.debug = 4;
     cgg.init();
 
-    // Needed otherwise debugging mode throws...
-    cgg.debug = 0;
     JSON.stringify = String;
 
     return {

--- a/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/protovis.js
+++ b/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/protovis.js
@@ -3573,11 +3573,19 @@ pv.Scale.quantitative = function() {
         increment = function(d) { d.setSeconds(d.getSeconds() + step*dateTickPrecision/1000);};
       }
 
-
-      while (true) {
-        increment(date);
-        if (date > max) break;
+      if (pv.get(options, 'roundInside', true)) {
+        while (true) {
+          increment(date);
+          if (date > max) break;
+          dates.push(new Date(date));
+        }
+      } else {
         dates.push(new Date(date));
+        while (true) {
+          increment(date);
+          dates.push(new Date(date));
+          if (date > max) break;
+        }
       }
       return reverse ? dates.reverse() : dates;
     }
@@ -7428,7 +7436,7 @@ pv.SvgScene.lineIntersect = function(o1, d1, o2, d2) {
 
   NOTE:
   As yy points down, and because of the way Vector.perp() is written,
-  perp() corresponds to rotating 90º clockwise.
+  perp() corresponds to rotating 90ï¿½ clockwise.
 
   -----
 

--- a/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/pvc.js
+++ b/core/src/main/javascript/pt/webdetails/cgg/resources/ccc/2.0-analyzer/pvc.js
@@ -12632,7 +12632,7 @@ def.type('pvc.visual.Sign')
 
     defaultColorSceneScale: function(){
         return this._defaultColorSceneScale ||
-               (defaultColorSceneScale = this._initDefaultColorSceneScale());
+               (this._defaultColorSceneScale = this._initDefaultColorSceneScale());
     },
 
     defaultColor: function(type){
@@ -14065,7 +14065,7 @@ var cartAxis_optionsDef = def.create(axis_optionsDef, {
     DomainRoundMode: {
         resolve: resolveNormal,
         cast:    String,
-        value:   'none'
+        value:   'tick'
     },
     TickExponentMin: {
         resolve: resolveNormal,
@@ -21336,7 +21336,7 @@ pvc.AxisPanel = pvc.BasePanel.extend({
     font: '9px sans-serif', // label font
     labelSpacingMin: 1,
     // To be used in linear scales
-    domainRoundMode: 'none',
+    domainRoundMode: 'tick',
     desiredTickCount: null,
     tickExponentMin:  null,
     tickExponentMax:  null,

--- a/core/src/test/java/pt/webdetails/cgg/AnalyzerTimeZoneTest.java
+++ b/core/src/test/java/pt/webdetails/cgg/AnalyzerTimeZoneTest.java
@@ -1,0 +1,112 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+
+
+package pt.webdetails.cgg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import pt.webdetails.cpf.utils.CharsetHelper;
+
+public class AnalyzerTimeZoneTest {
+  private static final Pattern DATE_TICK_PATTERN = Pattern.compile( "((?:0[1-9]|1[0-2])/\\d{4})" );
+  private static final String[] CHART_TYPES = { "Line", "StackedLine", "StackedArea", "Dot" };
+
+  @Before
+  public void setUp() {
+    CggBoot.init();
+  }
+
+  @Test
+  public void preservesJvmTimezoneAndKeepsExpectedMonthlyAxis() throws Exception {
+    final TimeZone originalTimeZone = TimeZone.getDefault();
+    final TimeZone serverTimeZone = TimeZone.getTimeZone( "GMT+02:00" );
+    final TimeZone utcTimeZone = TimeZone.getTimeZone( "UTC" );
+
+    try {
+      for ( final String chartType : CHART_TYPES ) {
+        TimeZone.setDefault( serverTimeZone );
+
+        final byte[] serverZoneSvg = executeSvg( "timezone/analyzer-timezone-svg-test.js", chartType );
+
+        assertEquals( serverTimeZone.getID(), TimeZone.getDefault().getID() );
+
+        TimeZone.setDefault( utcTimeZone );
+        final byte[] utcSvg = executeSvg( "timezone/analyzer-timezone-svg-test.js", chartType );
+
+        final List<String> serverZoneTicks = extractMonthlyTicks( serverZoneSvg );
+        final List<String> utcTicks = extractMonthlyTicks( utcSvg );
+
+        assertFalse( chartType, serverZoneTicks.isEmpty() );
+        assertEquals( chartType, "07/2005", serverZoneTicks.get( serverZoneTicks.size() - 1 ) );
+        assertEquals( chartType, utcTicks, serverZoneTicks );
+      }
+    } finally {
+      TimeZone.setDefault( originalTimeZone );
+    }
+  }
+
+  private List<String> extractMonthlyTicks( final byte[] svg ) throws Exception {
+    final String output = new String( svg, CharsetHelper.getEncoding() );
+    final Matcher matcher = DATE_TICK_PATTERN.matcher( output );
+    final List<String> ticks = new ArrayList<>();
+
+    while ( matcher.find() ) {
+      ticks.add( matcher.group( 1 ) );
+    }
+
+    return ticks;
+  }
+
+  private byte[] executeSvg( final String resourcePath, final String chartType ) throws Exception {
+    final URL resource = AnalyzerTimeZoneTest.class.getClassLoader().getResource( resourcePath );
+    if ( resource == null ) {
+      throw new IllegalArgumentException( resourcePath );
+    }
+
+    final File file = new File( resource.toURI() );
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final URL scriptContext = file.getParentFile().toURI().toURL();
+    final DefaultCgg cgg = new DefaultCgg( out, scriptContext );
+    final HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put( "cccVersion", "2.0-analyzer" );
+    parameters.put( "chartType", chartType );
+
+    cgg.draw( new DrawParameters(
+      file.getName(),
+      "SVG",
+      "svg",
+      800,
+      600,
+      false,
+      Locale.US,
+      parameters ) );
+
+    return out.toByteArray();
+  }
+}

--- a/core/src/test/resources/timezone/analyzer-timezone-svg-test.js
+++ b/core/src/test/resources/timezone/analyzer-timezone-svg-test.js
@@ -1,0 +1,103 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+
+
+lib('protovis-bundle.js');
+
+cgg.init();
+
+var pvc = require('cdf/lib/CCC/pvc');
+var chartType = String(params.get('chartType') || 'Line');
+
+var resultset = [];
+var value = 1;
+
+for (var year = 2003; year <= 2005; year++) {
+  var lastMonth = year === 2005 ? 5 : 12;
+  for (var month = 1; month <= lastMonth; month++) {
+    var monthText = month < 10 ? '0' + month : String(month);
+    resultset.push(['North', year + '-' + monthText + '-01', value++]);
+    resultset.push(['South', year + '-' + monthText + '-01', value++]);
+  }
+}
+
+var data = {
+  resultset: resultset,
+  metadata: [{
+    colIndex: 0,
+    colType: 'String',
+    colName: 'Series'
+  }, {
+    colIndex: 1,
+    colType: 'String',
+    colName: 'Categories'
+  }, {
+    colIndex: 2,
+    colType: 'Numeric',
+    colName: 'Value'
+  }]
+};
+
+var root = document.lastChild;
+var canvas = document.createElement('g');
+canvas.setAttribute('id', 'canvas');
+root.appendChild(canvas);
+
+var chartClasses = {
+  Line: pvc.LineChart,
+  StackedLine: pvc.StackedLineChart,
+  StackedArea: pvc.StackedAreaChart,
+  Dot: pvc.DotChart
+};
+
+var ChartClass = chartClasses[chartType];
+if (!ChartClass) {
+  throw new Error('Unsupported chartType: ' + chartType);
+}
+
+var chart = new ChartClass({
+  width: 800,
+  height: 600,
+  canvas: 'canvas',
+  orientation: 'horizontal',
+  timeSeries: true,
+  timeSeriesFormat: '%Y-%m-%d',
+  showDots: true,
+  showTooltips: false,
+  legend: false,
+  xAxisSize: 30,
+  yAxisSize: 30,
+  xAxisFullGrid: true,
+  yAxisFullGrid: true
+});
+
+chart.setData(data, {
+  crosstabMode: false,
+  seriesInRows: false
+});
+
+chart.render();
+
+var error = typeof chart.getLastRenderError === 'function'
+  ? chart.getLastRenderError()
+  : null;
+if (error) {
+  throw error;
+}
+
+if (canvas.lastChild) {
+  root.appendChild(canvas.lastChild);
+}
+root.setAttribute('width', '800');
+root.setAttribute('height', '600');
+root.setAttribute('viewBox', '0 0 800 600');


### PR DESCRIPTION
This PR reverts the global UTC override introduced in `AbstractScriptFactory`

The previous change set the default timezone to UTC during CGG script factory initialization. The UTC override was applied at a global level, so it changed behavior for every script executed through CGG rather than only the targeted Analyzer case.

The correct handling for the [original bug](https://pentaho-eng.atlassian.net/browse/ANALYZER-4174) already exists in the current CCC/Protovis runtime used by Analyzer export, so the global timezone override should be removed instead of kept as a workaround.
